### PR TITLE
Bugfix: xgboost</lib/native/libhdfs.a: could not read symbols: Bad value

### DIFF
--- a/make/config.mk
+++ b/make/config.mk
@@ -22,3 +22,8 @@ USE_S3 = 1
 
 # path to libjvm.so
 LIBJVM=$(JAVA_HOME)/jre/lib/amd64/server
+
+# HADOOP_CDH via yum
+HADOOP_CDH_BINARY = 1
+
+


### PR DESCRIPTION
For Hadoop_CDH distribution (yum installed), there exists no libhdfs.so(dynamic lib) just libhdfs.a(static lib). 
A switch "HADOOP_CDH_BINARY" is added for this situation, it enables static compiling, so xgboost
wil not search for libhdfs.so anymore while running.