### PR TITLE
Update deps.mk

### DIFF
--- a/make/deps.mk
+++ b/make/deps.mk
@@ -20,7 +20,7 @@ ${DEPS_PATH}/include/glog/logging.h: | ${DEPS_PATH}/include/google/gflags.h
 	$(eval FILE=v0.3.4.tar.gz)
 	$(eval DIR=glog-0.3.4)
 	rm -rf $(FILE) $(DIR)
-	wget https://github.com/google/glog/archive/$(FILE) && tar -zxf $(FILE)
+	wget https://github.com/google/glog/archive/$(FILE) -O $(FILE) && tar -zxf $(FILE)
 	cd $(DIR) && ./configure -prefix=$(DEPS_PATH) --with-gflags=$(DEPS_PATH) && $(MAKE) && $(MAKE) install
 	rm -rf $(FILE) $(DIR)
 


### PR DESCRIPTION
wget should be used with -O and explicit filename otherwise this breaks if server returns 300 redirect and wget stores the file under the redirected name:

    wget https://github.com/google/glog/archive/v0.3.4.tar.gz && tar -zxf v0.3.4.tar.gz
    HTTP request sent, awaiting response... 302 Found
    Location: https://codeload.github.com/google/glog/tar.gz/v0.3.4 [following]
    Saving to: “v0.3.4.1”
    tar (child): v0.3.4.tar.gz: Cannot open: No such file or directory