### PR TITLE
Added libgoogle-glog-dev package as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Build & Run
   >= 13.10
 
 ```
-sudo apt-get update && sudo apt-get install -y build-essential git
+sudo apt-get update && sudo apt-get install -y build-essential git libgoogle-glog-dev
 ```
 
 * Type `make` to build all deps and tools


### PR DESCRIPTION
Compiling in a fresh ubuntu 14.04 machine yields

/usr/bin/ld: cannot find -lglog
collect2: error: ld returned 1 exit status