### PR TITLE
build error fix. inconsistant call of io::FileSystem::GetInstance

### DIFF
--- a/learn/base/match_file.h
+++ b/learn/base/match_file.h
@@ -19,7 +19,7 @@ inline void MatchFile(const std::string& pattern,
   // find all files
   dmlc::io::URI path_uri(path.c_str());
   dmlc::io::FileSystem *fs =
-      dmlc::io::FileSystem::GetInstance(path_uri.protocol);
+      dmlc::io::FileSystem::GetInstance(path_uri);
   std::vector<io::FileInfo> info;
   fs->ListDirectory(path_uri, &info);
 


### PR DESCRIPTION
build error info : 
```
g++ -O3 -ggdb -Wall -std=c++11 -I./ -I../ -I../../repo/ps-lite/src -I../../repo/dmlc-core/include -I../../repo/dmlc-core/src -I/home/z/dev-pla/wormhole/deps/include -fopenmp -fPIC -DDMLC_USE_HDFS=0 -DDMLC_USE_S3=0 -DDMLC_USE_GLOG=1 -DDMLC_USE_AZURE=0   -c linear.cc -o build/linear.o
In file included from ../base/workload_pool.h:5:0,
                 from ../solver/data_parallel.h:8,
                 from ../solver/iter_solver.h:5,
                 from ../solver/minibatch_solver.h:5,
                 from async_sgd.h:5,
                 from linear.cc:1:
../base/match_file.h: In function ‘void dmlc::MatchFile(const string&, std::vector<std::basic_string<char> >*)’:
../base/match_file.h:22:58: error: no matching function for call to ‘dmlc::io::FileSystem::GetInstance(std::string&)’
       dmlc::io::FileSystem::GetInstance(path_uri.protocol);
                                                          ^
../base/match_file.h:22:58: note: candidate is:
In file included from ../base/match_file.h:2:0,
              from ../base/workload_pool.h:5,
              from ../solver/data_parallel.h:8,
              from ../solver/iter_solver.h:5,
              from ../solver/minibatch_solver.h:5,
               from async_sgd.h:5,
               from linear.cc:1:
../../repo/dmlc-core/src/io/filesys.h:84:22: note: static dmlc::io::FileSystem* dmlc::io::FileSystem::GetInstance(const dmlc::io::URI&)
   static FileSystem *GetInstance(const URI &path);
                      ^
../../repo/dmlc-core/src/io/filesys.h:84:22: note:   no known conversion for argument 1 from ‘std::string {aka std::basic_string<char>}’ to ‘const dmlc::io::URI&’
make[1]: *** [build/linear.o] Error 1



line 
static FileSystem *GetInstance(const URI &path);
```

This error is due to the incorrect argument of `GetInstance` in file `./learn/base/match_file.h` line 22.

This error can be fixed by changing `dmlc::io::FileSystem::GetInstance(path_uri.protocol)` to `dmlc::io::FileSystem::GetInstance(path_uri)`

